### PR TITLE
Fix errors due to the major update of NumPy

### DIFF
--- a/Tutorial/demo_mutag.py
+++ b/Tutorial/demo_mutag.py
@@ -11,10 +11,10 @@ import numpy as np
 
 # Load data
 # comment next line if data.mutag is in a different folder
-mutag_list = np.load("graphkernels/data.mutag")
+mutag_list = np.load("graphkernels/data.mutag", allow_pickle=True)
 
 # Uncomment next line if data.mutag is in your current folder
-#mutag_list = np.load("data.mutag")
+#mutag_list = np.load("data.mutag", allow_pickle=True)
 
 ### ALL KERNELS COMPUTE
 K1 = gk.CalculateEdgeHistKernel(mutag_list)

--- a/src/GKextCPy/setup.py
+++ b/src/GKextCPy/setup.py
@@ -13,7 +13,7 @@ import sys
 
 # Solve the chicken-and-egg problem of requiring packages *before* the
 # script has been parsed.
-for package in ['numpy', 'pkgconfig']:
+for package in ['numpy<2.0', 'pkgconfig']:
 
     # Don't try to install packages that already exist.
     try:
@@ -55,7 +55,7 @@ GKextCPy_module = Extension('_GKextCPy',
 )
 
 setup(name = 'GKextCPy',
-    version = '0.4.1',
+    version = '0.4.2',
     author = 'Elisabetta Ghisu',
     description = """Graph Kernels: building the extension Python module. This is a wrapper package from C++ to Python.""",
     ext_modules = [GKextCPy_module],


### PR DESCRIPTION
Thank you for sharing graph kernels implementation. I fixed 2 errors caused by the update of numpy.

* Some older numpy data types are used in `GKextCPy_wrap.cxx`. However, such older types are removed due to major update of numpy 2.0. I restricted the installed numpy version to be below 2.0.
* From numpy 1.15 to 1.16, the default value of load function was changed. I modified the code to explicitly specify the argument.